### PR TITLE
Fix class declaration detection

### DIFF
--- a/lib/dox/lib/dox_coffee.js
+++ b/lib/dox/lib/dox_coffee.js
@@ -262,7 +262,7 @@ exports.parseCodeContextCoffee = function(str, parent) {
   }
 
   // CoffeeScript class syntax
-  if (/[\s]+class +(\w+)/.exec(str)) {
+  if (/\bclass +(\w+)/.exec(str)) {
     return {
         type: 'class'
       , name: RegExp.$1


### PR DESCRIPTION
To be able to use something like this:

``` coffeescript
Application.register class Dispatcher ...
```
