### PR TITLE
Show filenames in missing links logs

### DIFF
--- a/lib/generate_doc.coffee
+++ b/lib/generate_doc.coffee
@@ -611,6 +611,7 @@ renderModules = (result, genopts) ->
       module: module
       properties: properties
       type: 'modules'
+      makeTypeLink: makeTypeLink
       result: result
       makeSeeLink: makeSeeLink
       convertLink: convertLink


### PR DESCRIPTION
was:
'[type]' link does not exist
now:
'[type]' link does not exist (in /app/assets/javascripts/app/base/bordeaux.coffee) 
