### PR TITLE
Fix extends regexp

### DIFF
--- a/lib/generate_doc.coffee
+++ b/lib/generate_doc.coffee
@@ -421,7 +421,7 @@ processComments = (comments) ->
           comment.override_link = tag.string
 
     if comment.ctx.type is 'class'
-      if /^class +\w+ +extends +(\w+)/.exec comment.code
+      if /^class +\w+ +extends +([\w\.]+)/.exec comment.code
         comment.extends.push RegExp.$1
         result.ids[RegExp.$1]?.subclasses.push comment.ctx.name
 


### PR DESCRIPTION
example: 

``` coffeescript
  class Bordeaux extends Backbone.Events
```

link was Backbone, not Backbone.Events
