### PR TITLE
add ability to add external-types by comments

### DIFF
--- a/lib/generate_doc.coffee
+++ b/lib/generate_doc.coffee
@@ -55,6 +55,9 @@ makeTypeLink = (rel_path, type) ->
     else
       return makeMissingLink type
     return "<a href='#{link}'>#{type}</a>"
+  if res = type.match(/\[(.*)\]\((.*)\)/)
+    types[res[1]] = res[2]
+    return "<a href='#{res[2]}'>#{res[1]}</a>"
   if res = type.match /(.*?)<(.*)>/
     return "#{makeTypeLink rel_path, res[1]}&lt;#{makeTypeLink rel_path, res[2]}&gt;"
   else


### PR DESCRIPTION
``` coffeescript
###*
  @uses [Backbone.Events](http://backbonejs.org/#Events-catalog)
###
class Yah
```

without adding type to crojsdoc.yaml external-types prop
