### PR TITLE
Overflow-hidden for sidenav lis

### DIFF
--- a/lib/style.css
+++ b/lib/style.css
@@ -12,6 +12,10 @@
 	margin-bottom: 20px;
 }
 
+.cormo-sidenav > li {
+	overflow: hidden;
+}
+
 .cormo-sidenav > li > a {
 	margin: 0 0 -1px 0;
 	border: 1px solid #e5e5e5;


### PR DESCRIPTION
If a property name is too long it gets out of the li box, so text is seen over the right block with content

![screen shot 2013-12-18 at 11 15 16 pm](https://f.cloud.github.com/assets/1782569/1776705/3abc4296-681a-11e3-8894-c2b61d0e9131.png)
