### PR TITLE
Fixed private checkbox left margin

### DIFF
--- a/themes/default/resources/style.css
+++ b/themes/default/resources/style.css
@@ -27,7 +27,7 @@ body {
 
 .options {
 	float: right;
-	margin-left: 15px;
+	margin-left: 30px;
 	margin-right: 15px;
 	margin-top: 6px;
 	


### PR DESCRIPTION
Checkbox no longer overlaps into the item before it within the nav bar
