### PR TITLE
Rename 'quite' -> 'quiet'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or, you can specify options in crojsdoc.yaml like this:
 ```
 output: doc
 title: Title
-quite: true
+quiet: true
 sources:
   - lib
   - guides

--- a/crojsdoc.yaml
+++ b/crojsdoc.yaml
@@ -1,6 +1,6 @@
 output: doc
 title: CroJSDoc
-quite: true
+quiet: true
 files: true
 sources:
   - src

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -23,8 +23,8 @@
       if (config.hasOwnProperty('title')) {
         options.title = config.title;
       }
-      if (config.hasOwnProperty('quite')) {
-        options.quite = config.quite === true;
+      if (config.hasOwnProperty('quiet' || config.hasOwnProperty('quite'))) {
+        options.quiet = config.quiet === true;
       }
       if (config.hasOwnProperty('files')) {
         options.files = config.files === true;
@@ -74,7 +74,7 @@
   _parseArguments = function(options) {
     var OptionParser, parser, switches;
     OptionParser = require('optparse').OptionParser;
-    switches = [['-o', '--output DIRECTORY', 'Output directory'], ['-t', '--title TITLE', 'Document Title'], ['-q', '--quite', 'less output'], ['-r', '--readme DIRECTORY', 'README.md directory path'], ['-f', '--files', 'included source files'], ['--external-types JSONFILE', 'external type definitions']];
+    switches = [['-o', '--output DIRECTORY', 'Output directory'], ['-t', '--title TITLE', 'Document Title'], ['-q', '--quiet', 'less output'], ['-r', '--readme DIRECTORY', 'README.md directory path'], ['-f', '--files', 'included source files'], ['--external-types JSONFILE', 'external type definitions']];
     parser = new OptionParser(switches);
     parser.on('*', function(opt, value) {
       if (value === void 0) {

--- a/lib/collect.js
+++ b/lib/collect.js
@@ -757,7 +757,7 @@
           this._addFile(path, data);
         }
         file_count_read++;
-        if (!(this.options.quite || is_test_mode)) {
+        if (!(this.options.quiet || is_test_mode)) {
           console.log(path + ' is processed');
         }
       }

--- a/lib/render.js
+++ b/lib/render.js
@@ -133,7 +133,7 @@
             if (error) {
               return console.error('failed to create ' + output_file);
             }
-            if (!_this.options.quite) {
+            if (!_this.options.quiet) {
               return console.log(output_file + ' is created');
             }
           });

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -21,8 +21,8 @@ _readConfig = (options) ->
       options.output = config.output
     if config.hasOwnProperty 'title'
       options.title = config.title
-    if config.hasOwnProperty 'quite'
-      options.quite = config.quite is true
+    if config.hasOwnProperty 'quiet' or config.hasOwnProperty 'quite'
+      options.quiet = config.quiet is true
     if  config.hasOwnProperty 'files'
       options.files = config.files is true
     if config.hasOwnProperty('readme') and typeof config.readme is 'string'
@@ -61,7 +61,7 @@ _parseArguments = (options) ->
   switches = [
     [ '-o', '--output DIRECTORY', 'Output directory' ]
     [ '-t', '--title TITLE', 'Document Title' ]
-    [ '-q', '--quite', 'less output' ]
+    [ '-q', '--quiet', 'less output' ]
     [ '-r', '--readme DIRECTORY', 'README.md directory path']
     [ '-f', '--files', 'included source files' ]
     [ '--external-types JSONFILE', 'external type definitions' ]

--- a/src/collect.coffee
+++ b/src/collect.coffee
@@ -540,7 +540,7 @@ class Collector
       if type is 'coffeescript' or type is 'javascript'
         @_addFile path, data
       file_count_read++
-      console.log path + ' is processed' if not (@options.quite or is_test_mode)
+      console.log path + ' is processed' if not (@options.quiet or is_test_mode)
 
     console.log 'Total ' + file_count_read + ' files processed' if not is_test_mode
 

--- a/src/render.coffee
+++ b/src/render.coffee
@@ -114,7 +114,7 @@ class Renderer
       output_file = "#{@options.output_dir}/#{output}.html"
       fs.writeFile output_file, result, (error) =>
         return console.error 'failed to create '+output_file if error
-        console.log output_file + ' is created' if not @options.quite
+        console.log output_file + ' is created' if not @options.quiet
 
   ##
   # Renders the README


### PR DESCRIPTION
Renamed in the option/argument parsing and the docs but allow
`quite:true/false` in the YAML config for backwards-compatibility